### PR TITLE
捨て牌エリアクラスのシステム、及びテストを実装しました。

### DIFF
--- a/src/main/java/ckn/yakitori/server/discard/discardArea.java
+++ b/src/main/java/ckn/yakitori/server/discard/discardArea.java
@@ -1,0 +1,65 @@
+package ckn.yakitori.server.discard;
+
+
+import ckn.yakitori.share.tile.tile;
+
+import java.util.ArrayList;
+import java.util.Objects;
+
+/**
+ * 捨て牌に起こせるアクションがある場合の処理を行います。
+ *
+ * @author mizu
+ * @version 1.0
+ */
+public class discardArea {
+
+
+    public ArrayList<discardTile> discardList = new ArrayList<>();
+
+    /**
+     * @param disTile 捨て牌の情報を追加します。
+     */
+    public void addDiscardTile(discardTile disTile) {
+        discardList.add(disTile);
+    }
+
+    /**
+     * 渡されたtile.getFullName(false)と同じものがarrayListの中にあるか確認
+     *
+     * @param Tile 捨て牌の情報
+     * @return 一致した牌情報
+     */
+    public ArrayList<Integer> check(tile Tile) {
+        ArrayList<Integer> match = new ArrayList<>();
+        for (int i = 0; i < getDiscardList().size(); i++) {
+            if (Objects.equals(getDiscardList().get(i).getTile().getFullName(), Tile.getFullName(false))) {
+                match.add(i);
+            }
+        }
+        return match;
+    }
+
+    /**
+     * 捨て牌リストの中身が全てヤオチュウハイで、鳴かれていなければtrueを返し流し満貫です。
+     *
+     * @return 流し満貫かどうかを返します。
+     */
+    public boolean Nagashicheck() {
+
+        for (int i = 0; i < getDiscardList().size(); i++) {
+            if (!getDiscardList().get(i).getTile().getYaochu() || getDiscardList().get(i).isStealed()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public ArrayList<discardTile> getDiscardList() {
+        return discardList;
+    }
+
+    public discardTile getDiscardList(int num) {
+        return discardList.get(num);
+    }
+}

--- a/src/main/java/ckn/yakitori/server/discard/discardArea.java
+++ b/src/main/java/ckn/yakitori/server/discard/discardArea.java
@@ -48,7 +48,10 @@ public class discardArea {
     public boolean Nagashicheck() {
 
         for (int i = 0; i < getDiscardList().size(); i++) {
-            if (!getDiscardList().get(i).getTile().getYaochu() || getDiscardList().get(i).isStealed()) {
+            if (!getDiscardList().get(i).getTile().getYaochu()) {
+                return false;
+            }
+            if (getDiscardList().get(i).isStealed()) {
                 return false;
             }
         }

--- a/src/main/java/ckn/yakitori/server/discard/discardTile.java
+++ b/src/main/java/ckn/yakitori/server/discard/discardTile.java
@@ -29,6 +29,14 @@ public class discardTile {
      */
     boolean isStealed;
 
+
+    /**
+     * @param Tile 　捨て牌の情報です。
+     */
+    public discardTile(tile Tile) {
+        this(Tile, false, false, false);
+    }
+
     /**
      * コンストラクタ　値を初期化します。
      *
@@ -37,13 +45,17 @@ public class discardTile {
      * @param isImmediatery  この牌がツモ切りされたかどうか
      * @param isStealed      　この牌が鳴かれて消えているかどうか
      */
-    discardTile(tile Tile, boolean isCalledRiichi, boolean isImmediatery, boolean isStealed) {
+
+    public discardTile(tile Tile, boolean isCalledRiichi, boolean isImmediatery, boolean isStealed) {
         this.Tile = Tile;
         this.isCalledRiichi = isCalledRiichi;
         this.isImmediately = isImmediatery;
         this.isStealed = isStealed;
     }
 
+    public tile getTile() {
+        return Tile;
+    }
 
     public boolean getCalledRiichi() {
         return this.isCalledRiichi;

--- a/src/test/java/ckn/yakitori/server/discard/discardAreaTest.java
+++ b/src/test/java/ckn/yakitori/server/discard/discardAreaTest.java
@@ -1,0 +1,49 @@
+package ckn.yakitori.server.discard;
+
+import ckn.yakitori.share.tile.tile;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class discardAreaTest {
+
+    @Test
+    void addDiscardTile() {
+        discardArea DiscardArea = new discardArea();
+        DiscardArea.addDiscardTile(new discardTile(new tile("1m")));
+        assertEquals("1m", DiscardArea.getDiscardList(0).getTile().getFullName(), "1");
+
+    }
+
+    @Test
+    void check() {
+        List<Integer> expected = new ArrayList<>(List.of(0));
+        discardArea DiscardArea = new discardArea();
+        DiscardArea.addDiscardTile(new discardTile(new tile("1m")));
+        DiscardArea.addDiscardTile(new discardTile(new tile("2m")));
+        DiscardArea.addDiscardTile(new discardTile(new tile("3m")));
+        DiscardArea.addDiscardTile(new discardTile(new tile("4m")));
+        DiscardArea.addDiscardTile(new discardTile(new tile("5m")));
+        DiscardArea.addDiscardTile(new discardTile(new tile("6m")));
+        assertIterableEquals(expected, DiscardArea.check(new tile("1m")));
+        DiscardArea.addDiscardTile(new discardTile(new tile("1m")));
+        DiscardArea.addDiscardTile(new discardTile(new tile("1m")));
+        expected.add(6);
+        expected.add(7);
+        assertIterableEquals(expected, DiscardArea.check(new tile("1m")));
+    }
+
+    @Test
+    void nagashicheck() {
+        discardArea DiscardArea = new discardArea();
+        DiscardArea.addDiscardTile(new discardTile(new tile("1z")));
+        assertTrue(DiscardArea.Nagashicheck(), "1");
+
+
+        DiscardArea.addDiscardTile(new discardTile(new tile("2m")));
+        assertFalse(DiscardArea.Nagashicheck(), "1");
+    }
+}

--- a/src/test/java/ckn/yakitori/server/discard/discardAreaTest.java
+++ b/src/test/java/ckn/yakitori/server/discard/discardAreaTest.java
@@ -42,7 +42,11 @@ class discardAreaTest {
         DiscardArea.addDiscardTile(new discardTile(new tile("1z")));
         assertTrue(DiscardArea.Nagashicheck(), "1");
 
+        DiscardArea = new discardArea();
+        DiscardArea.addDiscardTile(new discardTile(new tile("1z"), false, false, true));
+        assertFalse(DiscardArea.Nagashicheck(), "1");
 
+        DiscardArea = new discardArea();
         DiscardArea.addDiscardTile(new discardTile(new tile("2m")));
         assertFalse(DiscardArea.Nagashicheck(), "1");
     }


### PR DESCRIPTION
## 概要
ここでは捨て牌とtileの情報が一致しているかチェックし、流し満貫が可能かどうかの判定を行います。