### PR TITLE
W立直の役判定処理の追加とstatusGroupにW立直の処理を追加

### DIFF
--- a/src/main/java/ckn/yakitori/share/score/statusGroup.java
+++ b/src/main/java/ckn/yakitori/share/score/statusGroup.java
@@ -60,6 +60,11 @@ public class statusGroup {
      */
     boolean isRinsyan = false;
 
+    /**
+     * ダブル立直で上がったか
+     */
+    boolean isDoubleReach = false;
+
     private ArrayList<mentsu> mentsuList = new ArrayList<>();
     /**
      * 刻子を保存するリスト
@@ -470,6 +475,25 @@ public class statusGroup {
      */
     public statusGroup setRinsyan(boolean rinsyan) {
         isRinsyan = rinsyan;
+        return this;
+    }
+
+    /**
+     * isDoubleReachを取得します。
+     *
+     * @return isDoubleReach
+     */
+    public boolean isDoubleReach() {
+        return isDoubleReach;
+    }
+
+    /**
+     * isDoubleReachに値をセットします。
+     *
+     * @param doubleReach isDoubleReachにセットする値
+     */
+    public statusGroup setDoubleReach(boolean doubleReach) {
+        isDoubleReach = doubleReach;
         return this;
     }
 }

--- a/src/main/java/ckn/yakitori/share/yaku/doubleReach.java
+++ b/src/main/java/ckn/yakitori/share/yaku/doubleReach.java
@@ -1,0 +1,36 @@
+package ckn.yakitori.share.yaku;
+
+import ckn.yakitori.share.score.statusGroup;
+
+import static ckn.yakitori.share.yaku.yakuInfo.DOUBLE_REACH;
+
+public class doubleReach implements yaku {
+
+
+    private statusGroup StatusGroup;
+
+    public doubleReach(statusGroup StatusGroup) {
+        this.StatusGroup = StatusGroup;
+    }
+
+    /**
+     * 役が持つ飜数などのデータが取得できるEnumを返します。
+     *
+     * @return それぞれの役のEnum
+     */
+    @Override
+    public yakuInfo getYakuInfo() {
+
+        return DOUBLE_REACH;
+    }
+
+    /**
+     * 役判定の結果を返します。
+     *
+     * @return 役が成立しているかどうか
+     */
+    @Override
+    public boolean isCheckPass() {
+        return StatusGroup.isDoubleReach();
+    }
+}

--- a/src/test/java/ckn/yakitori/share/yaku/doubleReachTest.java
+++ b/src/test/java/ckn/yakitori/share/yaku/doubleReachTest.java
@@ -1,0 +1,32 @@
+package ckn.yakitori.share.yaku;
+
+import ckn.yakitori.share.score.statusGroup;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static ckn.yakitori.share.yaku.yakuInfo.DOUBLE_REACH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class doubleReachTest {
+
+    @Test
+    void getYakuInfo() {
+        assertEquals(DOUBLE_REACH, new doubleReach(new statusGroup()).getYakuInfo());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "true, true",
+            "false, false"
+    })
+
+    @DisplayName("ダブル立直をチェック")
+    void isCheckPass(boolean expected, boolean expectedDoubleReach) {
+        statusGroup sg = new statusGroup();
+        sg.setDoubleReach(expectedDoubleReach);
+        doubleReach DoubleReach = new doubleReach(sg);
+        assertEquals(expected, DoubleReach.isCheckPass());
+    }
+}


### PR DESCRIPTION
## 概要

W立直の役判定処理とテストの追加
また、statusGroupにW立直のテストを書く際のsetメソッドgetメソッドがなかったため追加


## レビュアーへ

何かあればいつでもどうぞ
